### PR TITLE
Support only displaying the bingo card

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,6 +323,14 @@ var bingoGenerator = {
         if (!(qs.pageBreaks === undefined)) {
             bingoGenerator.pageBreaks = qs.pageBreaks;
         }
+        if (qs.onlyCard === "true") {
+            $("#number").val(1);
+            $("h1").hide();
+            $("form").hide();
+            $("#footer").hide();
+            $("body").css("margin", 0);
+            $("table").css("margin", 0);
+        }
         if (!(qs.title === undefined) && !(qs.words === undefined)) {
             bingoGenerator.generate();
             dauber.init();


### PR DESCRIPTION
For online distribution of cards, we only want the card itself to be
visible. We can achieve this with a query parameter that hides
everything except the card.

Remove margins for better display on mobile devices

The footer is removed here as well - maybe something should be included? A link to the default page?